### PR TITLE
Generalized lex testing

### DIFF
--- a/lex/src/lib.rs
+++ b/lex/src/lib.rs
@@ -90,6 +90,12 @@ pub struct Pos {
     pub column: usize,
 }
 
+impl Pos {
+    pub fn new() -> Self {
+        Pos { line: 1, column: 0 }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Span {
     pub start: Pos,
@@ -99,8 +105,8 @@ pub struct Span {
 impl Span {
     pub fn new() -> Self {
         Span {
-            start: Pos { line: 1, column: 0 },
-            end: Pos { line: 1, column: 0 },
+            start: Pos::new(),
+            end: Pos::new(),
         }
     }
 }
@@ -317,6 +323,6 @@ pub fn lex(input: &str) -> TokenStream {
     TokenStream {
         input,
         index: 0,
-        pos: Pos { line: 1, column: 0 },
+        pos: Pos::new(),
     }
 }

--- a/lex/src/test/composites.rs
+++ b/lex/src/test/composites.rs
@@ -1,196 +1,85 @@
-use crate::test::update_span;
-use crate::*;
+use super::prelude::*;
 
 #[test]
 fn fn_def() {
-    let input = "fn lul(){}";
-    let mut lexed = lex(input);
-    let span = &mut Span::new();
-    assert_eq!(
-        Some((Token::KeyWord(KeyWord::Fn), update_span(span, 2, 0))),
-        lexed.next()
+    let pos = &mut Pos::new();
+    lex_test(
+        "fn lul(){}",
+        &[
+            (KeyWord(KeyWord::Fn), pos.update(2)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("lul"), pos.update(3)),
+            (Bracket(Bracket::Start), pos.update(1)),
+            (Bracket(Bracket::End), pos.update(1)),
+            (Curley(Bracket::Start), pos.update(1)),
+            (Curley(Bracket::End), pos.update(1)),
+        ],
     );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("lul"), update_span(span, 3, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert!(lexed.next().is_none())
 }
 
 #[test]
 fn fn_with_args() {
-    let input = "fn lul(a: u16, b: String){}";
-    let mut lexed = lex(input);
-    let span = &mut Span::new();
-    assert_eq!(
-        Some((Token::KeyWord(KeyWord::Fn), update_span(span, 2, 0))),
-        lexed.next()
+    let pos = &mut Pos::new();
+    lex_test(
+        "fn lul(a: u16, b: String){}",
+        &[
+            (KeyWord(KeyWord::Fn), pos.update(2)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("lul"), pos.update(3)),
+            (Bracket(Bracket::Start), pos.update(1)),
+            (Ident("a"), pos.update(1)),
+            (Colon, pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("u16"), pos.update(3)),
+            (Comma, pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("b"), pos.update(1)),
+            (Colon, pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("String"), pos.update(6)),
+            (Bracket(Bracket::End), pos.update(1)),
+            (Curley(Bracket::Start), pos.update(1)),
+            (Curley(Bracket::End), pos.update(1)),
+        ],
     );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("lul"), update_span(span, 3, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("a"), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Colon, update_span(span, 1, 0))), lexed.next());
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("u16"), update_span(span, 3, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Comma, update_span(span, 1, 0))), lexed.next());
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("b"), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Colon, update_span(span, 1, 0))), lexed.next());
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("String"), update_span(span, 6, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(None, lexed.next());
 }
 
 #[test]
 fn fn_with_return() {
-    let input = "fn argh() -> u16 {}";
-    let mut lexed = lex(input);
-    let span = &mut Span {
-        start: Pos { line: 1, column: 0 },
-        end: Pos { line: 1, column: 0 },
-    };
-
-    assert_eq!(
-        Some((Token::KeyWord(KeyWord::Fn), update_span(span, 2, 0))),
-        lexed.next()
+    let pos = &mut Pos::new();
+    lex_test(
+        "fn argh() -> u16 {}",
+        &[
+            (KeyWord(KeyWord::Fn), pos.update(2)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("argh"), pos.update(4)),
+            (Bracket(Bracket::Start), pos.update(1)),
+            (Bracket(Bracket::End), pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Arrow, pos.update(2)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("u16"), pos.update(3)),
+            (WhiteSpace, pos.update(1)),
+            (Curley(Bracket::Start), pos.update(1)),
+            (Curley(Bracket::End), pos.update(1)),
+        ],
     );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("argh"), update_span(span, 4, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Bracket(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Arrow, update_span(span, 2, 0))), lexed.next());
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("u16"), update_span(span, 3, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::Start), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Curley(Bracket::End), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(None, lexed.next());
 }
 
 #[test]
 fn let_decl() {
-    let input = "let a = b;";
-    let mut lexed = lex(input);
-    let span = &mut Span::new();
-    assert_eq!(
-        Some((Token::KeyWord(KeyWord::Let), update_span(span, 3, 0))),
-        lexed.next()
+    let pos = &mut Pos::new();
+    lex_test(
+        "let a = b;",
+        &[
+            (KeyWord(KeyWord::Let), pos.update(3)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("a"), pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Eq, pos.update(1)),
+            (WhiteSpace, pos.update(1)),
+            (Ident("b"), pos.update(1)),
+            (Semi, pos.update(1)),
+        ],
     );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("a"), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Eq, update_span(span, 1, 0))), lexed.next());
-    assert_eq!(
-        Some((Token::WhiteSpace, update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(
-        Some((Token::Ident("b"), update_span(span, 1, 0))),
-        lexed.next()
-    );
-    assert_eq!(Some((Token::Semi, update_span(span, 1, 0))), lexed.next());
-    assert_eq!(None, lexed.next());
 }

--- a/lex/src/test/floats.rs
+++ b/lex/src/test/floats.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use super::prelude::*;
 
 #[test]
 fn float() {
@@ -18,79 +18,31 @@ fn float() {
 
 #[test]
 fn typed_float() {
-    let input = "123.123f32";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!(
-            (
-                Token::Float("123.123"),
-                Span {
-                    start: Pos { line: 1, column: 0 },
-                    end: Pos { line: 1, column: 7 }
-                }
-            ),
-            (
-                Token::Ident("f32"),
-                Span {
-                    start: Pos { line: 1, column: 7 },
-                    end: Pos {
-                        line: 1,
-                        column: 10
-                    }
-                }
-            )
-        ),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test(
+        "123.123f32",
+        &[
+            (Token::Float("123.123"), pos.update(7)),
+            (Token::Ident("f32"), pos.update(3)),
+        ],
+    );
 }
 
 #[test]
 fn float_with_seperator() {
-    let input = "1_230.123";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!((
-            Token::Float("1_230.123"),
-            Span {
-                start: Pos { line: 1, column: 0 },
-                end: Pos { line: 1, column: 9 }
-            }
-        )),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test("1_230.123", &[(Token::Float("1_230.123"), pos.update(9))]);
 }
 
 #[test]
 fn almost_float() {
-    let input = "1_230._123";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!(
-            (
-                Token::Int("1_230"),
-                Span {
-                    start: Pos { line: 1, column: 0 },
-                    end: Pos { line: 1, column: 5 }
-                }
-            ),
-            (
-                Token::Dot,
-                Span {
-                    start: Pos { line: 1, column: 5 },
-                    end: Pos { line: 1, column: 6 }
-                }
-            ),
-            (
-                Token::Ident("_123"),
-                Span {
-                    start: Pos { line: 1, column: 6 },
-                    end: Pos {
-                        line: 1,
-                        column: 10
-                    }
-                }
-            ),
-        ),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test(
+        "1_230._123",
+        &[
+            (Token::Int("1_230"), pos.update(5)),
+            (Token::Dot, pos.update(1)),
+            (Token::Ident("_123"), pos.update(4)),
+        ],
+    );
 }

--- a/lex/src/test/integers.rs
+++ b/lex/src/test/integers.rs
@@ -1,58 +1,25 @@
-use crate::*;
+use super::prelude::*;
 
 #[test]
 fn int() {
-    let input = "123";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!((
-            Token::Int("123"),
-            Span {
-                start: Pos { line: 1, column: 0 },
-                end: Pos { line: 1, column: 3 }
-            }
-        )),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test("123", &[(Token::Int("123"), pos.update(3))]);
 }
 
 #[test]
 fn typed_int() {
-    let input = "123u32";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!(
-            (
-                Token::Int("123"),
-                Span {
-                    start: Pos { line: 1, column: 0 },
-                    end: Pos { line: 1, column: 3 }
-                }
-            ),
-            (
-                Token::Ident("u32"),
-                Span {
-                    start: Pos { line: 1, column: 3 },
-                    end: Pos { line: 1, column: 6 }
-                }
-            )
-        ),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test(
+        "123u32",
+        &[
+            (Token::Int("123"), pos.update(3)),
+            (Token::Ident("u32"), pos.update(3)),
+        ],
+    );
 }
 
 #[test]
 fn int_with_seperator() {
-    let input = "123_000";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec!((
-            Token::Int("123_000"),
-            Span {
-                start: Pos { line: 1, column: 0 },
-                end: Pos { line: 1, column: 7 }
-            }
-        )),
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test("123_000", &[(Token::Int("123_000"), pos.update(7))]);
 }

--- a/lex/src/test/keywords.rs
+++ b/lex/src/test/keywords.rs
@@ -1,34 +1,13 @@
-use crate::*;
+use super::prelude::*;
 
 #[test]
 fn lex_fn() {
-    let input = "fn";
-    let lexed = lex(input).collect::<Vec<_>>();
-    assert_eq!(
-        vec![(
-            Token::KeyWord(KeyWord::Fn),
-            Span {
-                start: Pos { line: 1, column: 0 },
-                end: Pos { line: 1, column: 2 }
-            }
-        )],
-        lexed
-    )
+    let pos = &mut Pos::new();
+    lex_test("fn", &[(Token::KeyWord(KeyWord::Fn), pos.update(2))]);
 }
 
 #[test]
 fn lex_let() {
-    let input = "let";
-    let mut lexed = lex(input);
-    assert_eq!(
-        Some((
-            Token::KeyWord(KeyWord::Let),
-            Span {
-                start: Pos { line: 1, column: 0 },
-                end: Pos { line: 1, column: 3 }
-            }
-        )),
-        lexed.next()
-    );
-    assert!(lexed.next().is_none())
+    let pos = &mut Pos::new();
+    lex_test("let", &[(Token::KeyWord(KeyWord::Let), pos.update(3))]);
 }

--- a/lex/src/test/string_literals.rs
+++ b/lex/src/test/string_literals.rs
@@ -1,17 +1,7 @@
-use crate::test::update_span;
-use crate::*;
+use super::prelude::*;
 
 #[test]
 fn empty() {
-    let input = "\"\"";
-    let mut lexed = lex(input);
-    let span = &mut Span::new();
-    assert_eq!(
-        Some((
-            Token::StringLiteral(Cow::Borrowed("")),
-            update_span(span, 2, 0)
-        )),
-        lexed.next()
-    );
-    assert_eq!(None, lexed.next());
+    let pos = &mut Pos::new();
+    lex_test("\"\"", &[(StringLiteral(Cow::Borrowed("")), pos.update(2))]);
 }


### PR DESCRIPTION
All the test currently follow the same structure. Most of the logic in them are boiler plate, so I've extracted this into a function. This function also fixes a minor problem with some of the tests.
If the lexer didn't terminate for some reason a collect would run forever.
I've "solved" this problem by limiting the resulting list to be at most one longer than the expected input. This will give the same behaviour on correct lexings while still catching potentially hanging once, as they would be longer than expected.
I've further seperated the comparison and the halt assertions, so that it's easier to tell them apart.